### PR TITLE
fix starting node with `testnet` flag

### DIFF
--- a/start_and_stop_a_node.sh
+++ b/start_and_stop_a_node.sh
@@ -37,10 +37,11 @@ do
     if $3
     then
     echo "start node.. testnet on port: "$port
-    if $4
-    then
-    cmdOpt=$(cat ../../testnet_files/cli_opts)
-    fi
+    cmdOpt='--testnet'
+        if $4
+        then
+        cmdOpt=$(cat ../../testnet_files/cli_opts)
+        fi
     else
     echo "start node.. mainnet on port: "$port
     fi


### PR DESCRIPTION
currently, $3 (is testnet?) is ignored and loads a normal mainnet node.
this fixes it.

this PR blocks #4