### PR TITLE
migrate to tcp

### DIFF
--- a/start_and_stop_a_node.sh
+++ b/start_and_stop_a_node.sh
@@ -46,7 +46,7 @@ do
     echo "start node.. mainnet on port: "$port
     fi
     echo "cmdOpt ="$cmdOpt
-    java -jar iri-$1.jar -p $port -u $port -t `expr $port + $5` -n 'udp://localhost:'`expr $port - 1`' udp://localhost:'`expr $port + 1` $cmdOpt &> iri.log &
+    java -jar iri-$1.jar -p $port -u $port -t `expr $port + $5` -n 'tcp://localhost:'`expr $port - 1`' tcp://localhost:'`expr $port + 1` $cmdOpt &> iri.log &
     echo $! > iri.pid
     cd ..
     ((port++))


### PR DESCRIPTION
### Description

Use only TCP due to https://github.com/iotaledger/iri/pull/1393/ that deprecated UDP support