### PR TITLE
Extend wait time for localsnapshots-db tests to pass

### DIFF
--- a/start_and_stop_a_node.sh
+++ b/start_and_stop_a_node.sh
@@ -60,7 +60,7 @@ done
 
 #give time to the node to init
 #TODO instead of sleep sample API until it is up
-sleep 40
+sleep 75
 if [ -n "$6" ];
 then
     echo "start python script.."


### PR DESCRIPTION
Needed for https://github.com/iotaledger/iri/pull/1584 to pass. There is a seg fault created by stopping the node while it is actively pushing spent addresses into the `localsnapshots-db`. Giving the node the extra bit of time to wrap up this process makes the test pass rather than fail. 