### PR TITLE
Add node to sync test

### DIFF
--- a/Nightly-Tests/Sync-Tests/config.yml
+++ b/Nightly-Tests/Sync-Tests/config.yml
@@ -18,9 +18,7 @@ default_args: &args
    '--zmq-enable-tcp',
    'true',
    '--zmq-port',
-   '5566',
-   '--local-snapshots-enabled',
-   'false'
+   '5566'
   ]
 
 default_ixi: &ixi
@@ -42,7 +40,7 @@ db_empty: &db_empty
 
 db_local_snapshot: &db_local_snapshot
   db: https://s3.eu-central-1.amazonaws.com/iotaledger-dbfiles/dev/SyncTestsLocalSnapshotDb.tar
-  db_checksum: a46ddb2afa422ec95b66ebe8a38000c539ce16f92cf360d45ef82bb5fd8ff6c2
+  db_checksum: 4c160bb790a38f40833e44ae278b1b2422fe37c629c8b5a5091856fc99072ead
   iri_args: *args
   ixis: *ixi
 
@@ -66,11 +64,9 @@ nodes:
     neighbors: 
       - tcp://nodeA:15600
       - tcp://nodeB:15600
-      - tcp://nodeD:15600
 
   nodeD:
     <<: *db_empty
     neighbors:
       - tcp://nodeA:15600
       - tcp://nodeB:15600
-      - tcp://nodeC:15600

--- a/Nightly-Tests/Sync-Tests/config.yml
+++ b/Nightly-Tests/Sync-Tests/config.yml
@@ -40,22 +40,37 @@ db_empty: &db_empty
   iri_args: *args
   ixis: *ixi
 
+db_local_snapshot: &db_local_snapshot
+  db: https://s3.eu-central-1.amazonaws.com/iotaledger-dbfiles/dev/SyncTestsLocalSnapshotDb.tar
+  db_checksum: a46ddb2afa422ec95b66ebe8a38000c539ce16f92cf360d45ef82bb5fd8ff6c2
+  iri_args: *args
+  ixis: *ixi
+
 nodes:
   nodeA: #name
     <<: *db_full
     neighbors: 
       - tcp://nodeB:15600
       - tcp://nodeC:15600
+      - tcp://nodeD:15600
 
   nodeB:
     <<: *db_full
     neighbors: 
       - tcp://nodeA:15600
       - tcp://nodeC:15600
+      - tcp://nodeD:15600
 
   nodeC:
-    <<: *db_empty
+    <<: *db_local_snapshot
     neighbors: 
       - tcp://nodeA:15600
       - tcp://nodeB:15600
+      - tcp://nodeD:15600
 
+  nodeD:
+    <<: *db_empty
+    neighbors:
+      - tcp://nodeA:15600
+      - tcp://nodeB:15600
+      - tcp://nodeC:15600

--- a/Nightly-Tests/Sync-Tests/createCluster.sh
+++ b/Nightly-Tests/Sync-Tests/createCluster.sh
@@ -79,6 +79,8 @@ fi
 
 echo "Tearing down cluster" 
 timeout 10 tiab/teardown_cluster.py -t $UUID -n $K8S_NAMESPACE
+kubectl delete pods --all
+kubectl delete services --all
 
 echo "Deactivating"
 deactivate

--- a/Nightly-Tests/Sync-Tests/createCluster.sh
+++ b/Nightly-Tests/Sync-Tests/createCluster.sh
@@ -79,8 +79,6 @@ fi
 
 echo "Tearing down cluster" 
 timeout 10 tiab/teardown_cluster.py -t $UUID -n $K8S_NAMESPACE
-kubectl delete pods --all
-kubectl delete services --all
 
 echo "Deactivating"
 deactivate

--- a/Nightly-Tests/Sync-Tests/runZMQScans.py
+++ b/Nightly-Tests/Sync-Tests/runZMQScans.py
@@ -103,7 +103,7 @@ def scan_sockets(test, socket_list, socket_poll):
 def make_graphs():
     nodes = test.get_nodes()
     for node in nodes:
-        if test.get_index_list_length(node) > 1:
+        if test.get_index_list_length(node) > 2:
             graphing.make_graph(num_tests=test.get_index_list_length(node),
                                 inputs=test.get_node_index_list(node),
                                 file='{}-Sync.png'.format(node),

--- a/Nightly-Tests/Sync-Tests/runZMQScans.py
+++ b/Nightly-Tests/Sync-Tests/runZMQScans.py
@@ -44,7 +44,7 @@ def get_latest_solid_milestones(test, time_elapsed):
         index = response.get('latestSolidSubtangleMilestoneIndex')
         if test.get_latest_milestone() == 0:
             index = response.get('latestMilestoneIndex')
-            if node == 'nodeC':
+            if node == 'nodeD':
                 index = 0
         logger.info("Node: {}  Index: {}".format(node, index))
         test.add_index(node, index, time_elapsed)
@@ -153,7 +153,7 @@ while True:
     iteration += 1
     socket_poll = dict(poller.poll(500))
     data = test.get_furthest_milestone()
-    node = 'nodeC'
+    node = 'nodeD'
 
     time_elapsed = time() - start
     if len(socket_poll) != 0:
@@ -168,7 +168,7 @@ while True:
         logger.info("Time elapsed: {}".format(int(time_elapsed)))        
         logger.info("Node states: {}".format(sync_list))
         logger.info("{} index: {}/{}\n".format(data['node'], data['index'], test.get_latest_milestone()))
-        logger.info("{} / {} transactions processed".format(get_total_transactions(test, 'nodeC'), get_total_transactions(test,'nodeA')))
+        logger.info("{} / {} transactions processed".format(get_total_transactions(test, 'nodeD'), get_total_transactions(test,'nodeA')))
         get_latest_solid_milestones(test, time_elapsed)
 
     if all(sync_list[state] is True for state in sync_list):
@@ -177,7 +177,7 @@ while True:
         logger.info("Syncing took: {} seconds".format(time_elapsed))
         make_graphs()
 
-        file_logger.info("nodeC\nindexes: \n{}\nindex timestamps: \n{}\ntransactions arrival timestamps: \n{}\n".format(test.get_node_index_list('nodeC'), test.get_node_index_list_timestamps('nodeC'), test.get_transactions_timestamps('nodeC')))
+        file_logger.info("nodeD\nindexes: \n{}\nindex timestamps: \n{}\ntransactions arrival timestamps: \n{}\n".format(test.get_node_index_list('nodeD'), test.get_node_index_list_timestamps('nodeD'), test.get_transactions_timestamps('nodeD')))
 
         sys.exit()
 

--- a/Nightly-Tests/utils/graph_tools.py
+++ b/Nightly-Tests/utils/graph_tools.py
@@ -84,6 +84,8 @@ def make_sync_graphs(x_axis, inputs, log_directory, file, title, sync_indexes):
 
     plt.ylim(y_min, y_max)
     plt.title(title)
+    plt.xlabel("Time (s)")
+    plt.ylabel("Tx's Received")
     plt.legend()
 
     plt.savefig(log_directory + file)


### PR DESCRIPTION
### Description 
Adds an additional node to the sync test that starts without a db, but has the local snapshot files/db present, as per https://github.com/iotaledger/iri/issues/1318. Also includes a config change to enable snapshots as well as adding x and y axis labels to the graph outputs. 